### PR TITLE
fix(logger): change use print option to variable

### DIFF
--- a/Source/AppleLogger/Setting.swift
+++ b/Source/AppleLogger/Setting.swift
@@ -13,7 +13,7 @@ extension Logger {
         public var logLevel: LogLevel? = .debug
         
         /// Use `print` to show logs  instead of `OS_log` when set to `true`
-        public var usePrint: Bool = false
+        public let usePrint: Bool
         
         /// A variable used for displaying `subsystem` value in console
         public let subsystem: String
@@ -24,9 +24,12 @@ extension Logger {
         /// An internal variable used to execute `os_log`
         var osLog: OSLog
         
-        public init(subsystem: String, category: String) {
+        public init(subsystem: String, category: String, usePrint: Bool = false) {
             self.subsystem = subsystem
             self.category = category
+            
+            self.usePrint = usePrint
+            
             self.osLog = OSLog(subsystem: subsystem, category: category)
         }
     }

--- a/Source/AppleLogger/Setting.swift
+++ b/Source/AppleLogger/Setting.swift
@@ -13,7 +13,7 @@ extension Logger {
         public var logLevel: LogLevel? = .debug
         
         /// Use `print` to show logs  instead of `OS_log` when set to `true`
-        public let usePrint: Bool = false
+        public var usePrint: Bool = false
         
         /// A variable used for displaying `subsystem` value in console
         public let subsystem: String

--- a/Test/AppleLogger/LoggerTest.swift
+++ b/Test/AppleLogger/LoggerTest.swift
@@ -24,7 +24,6 @@ final class LoggerTest: XCTestCase {
         
         var configAfterChange = defaultSetting
         configAfterChange.logLevel = .none
-        configAfterChange.usePrint = true
 
         XCTAssertNotNil(configBeforeChange.osLog)
         XCTAssertNotNil(configAfterChange.osLog)
@@ -32,25 +31,17 @@ final class LoggerTest: XCTestCase {
     }
     
     func test__use_print_option() {
-        let printerExp = XCTestExpectation(description: "Should show print, not log")
-        let loggerExp = XCTestExpectation(description: "Should show log, not print")
+        let printerExp = XCTestExpectation(description: "Should use print, not log")
         
-        var commonConfiguration = defaultSetting
-        commonConfiguration.usePrint = true
+        let printerSetting = Logger.Setting(subsystem: "", category: "", usePrint: true)
         
-        let testPrinter = Logger(setting: commonConfiguration)
+        let testPrinter = Logger(setting: printerSetting)
         testPrinter.logService = MockPrintService(expectation: printerExp, showLogs: false)
-        
-        commonConfiguration.usePrint = false
-        let testLogger = Logger(setting: commonConfiguration)
-        testLogger.logService = MockLogService(expectation: loggerExp, showLogs: false)
         
         // XCTFail will be triggered if `log` is called in this case.
         printAllLogs(testPrinter)
-        
-        // XCTFail will be triggered if `print` is called in this case.
-        printAllLogs(testLogger)
-        wait(for: [printerExp, loggerExp], timeout: 0.5)
+
+        wait(for: [printerExp], timeout: 0.5)
     }
     
     func test__should_not_show_lower_level_logs() {


### PR DESCRIPTION
### 개요
- 테스트가 실패하는 케이스가 있어 확인해보니 `usePrint`가 상수처리되어있었음
- 이에 `usePrint`를 변수로 변경해 `logLevel`과 통일시킴