### PR TITLE
feature: add flat map like operation to contract

### DIFF
--- a/Test/Concurrency/Contract/Chain/ContractThenTest.swift
+++ b/Test/Concurrency/Contract/Chain/ContractThenTest.swift
@@ -56,4 +56,23 @@ final class ContractThenTest: XCTestCase {
             contract0.resolve(20)
         }
     }
+    
+    func test__then_return_contract_value() {
+        var contract = Contract<Int>()
+        let nestedContract = Contract<Int>()
+        
+        /// `then` in this case should return `Int`,
+        /// not `Contract<Int>`
+        contract = contract.then { _ -> Contract<Int> in
+            nestedContract
+        }
+        
+        ContractTest.expect(
+            contract: contract,
+            state: .resolved(13),
+            timeout: .seconds(1))
+        {
+            contract.resolve(13)
+        }
+    }
 }


### PR DESCRIPTION
### 개요 
- Saby `Contract`에 flatMap에 해당하는 연산자 추가

### 동작
- block 안에서 Contract<Result>를 리턴하면 `Contract<Contract<Result>>`가 아닌 `Contrac<Result>`를 리턴
```Swift
var contract = Contract<Int>()
let nestedContract = Contract<Int>()
        
/// `then` in this case should return `Int`,
/// not `Contract<Int>`
contract = contract.then { _ -> Contract<Int> in
    nestedContract
}
```