### PR TITLE
fix: improve a promise all via parameter pack

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test-unit:
-    runs-on: macos-12
+    runs-on: macos-15
     steps:
     - uses: actions/checkout@v2
     - run: swift test --parallel

--- a/Source/Concurrency/Promise/Composition/PromiseAll.swift
+++ b/Source/Concurrency/Promise/Composition/PromiseAll.swift
@@ -46,368 +46,40 @@ extension Promise where
         return promiseReturn
     }
     
-    public static func all<Value0, Value1, Failure0, Failure1>(
+    public static func all<each PromiseValue, each PromiseFailure>(
         on queue: DispatchQueue = .global(),
-        _ promise0: Promise<Value0, Failure0>,
-        _ promise1: Promise<Value1, Failure1>
-    ) -> Promise<(Value0, Value1), Error> {
-        let promiseReturn = Promise<(Value0, Value1), Error>(queue: queue)
+        _ promises: repeat Promise<each PromiseValue, each PromiseFailure>
+    ) -> Promise<(repeat each PromiseValue), Error> {
+        let promiseReturn = Promise<(repeat each PromiseValue), Error>(queue: queue)
+        
         let resolve = {
-            guard
-                case .resolved(let value0) = promise0.state.capture({ $0 }),
-                case .resolved(let value1) = promise1.state.capture({ $0 })
-            else {
-                return
+            let captures = (repeat (each promises).state.capture({ $0 }))
+            
+            for capture in repeat each captures {
+                guard case .resolved = capture
+                else { return }
             }
             
-            promiseReturn.resolve((value0, value1))
+            let resolved = (repeat (each captures).resolved!)
+            promiseReturn.resolve(resolved)
         }
         
-        promise0.subscribe(
-            queue: queue,
-            onResolved: { _ in resolve() },
-            onRejected: { promiseReturn.reject($0) },
-            onCanceled: { [weak promiseReturn] in promiseReturn?.cancel() }
-        )
-        promise1.subscribe(
-            queue: queue,
-            onResolved: { _ in resolve() },
-            onRejected: { promiseReturn.reject($0) },
-            onCanceled: { [weak promiseReturn] in promiseReturn?.cancel() }
-        )
-        
-        return promiseReturn
-    }
-    
-    public static func all<Value0, Value1, Value2, Failure0, Failure1, Failure2>(
-        on queue: DispatchQueue = .global(),
-        _ promise0: Promise<Value0, Failure0>,
-        _ promise1: Promise<Value1, Failure1>,
-        _ promise2: Promise<Value2, Failure2>
-    ) -> Promise<(Value0, Value1, Value2), Error> {
-        let promiseReturn = Promise<(Value0, Value1, Value2), Error>(queue: queue)
-        let resolve = {
-            guard
-                case .resolved(let value0) = promise0.state.capture({ $0 }),
-                case .resolved(let value1) = promise1.state.capture({ $0 }),
-                case .resolved(let value2) = promise2.state.capture({ $0 })
-            else {
-                return
-            }
-            
-            promiseReturn.resolve((value0, value1, value2))
+        for promise in repeat each promises {
+            promise.subscribe(
+                queue: queue,
+                onResolved: { _ in resolve() },
+                onRejected: { promiseReturn.reject($0) },
+                onCanceled: { [weak promiseReturn] in promiseReturn?.cancel() }
+            )
         }
-        
-        promise0.subscribe(
-            queue: queue,
-            onResolved: { _ in resolve() },
-            onRejected: { promiseReturn.reject($0) },
-            onCanceled: { [weak promiseReturn] in promiseReturn?.cancel() }
-        )
-        promise1.subscribe(
-            queue: queue,
-            onResolved: { _ in resolve() },
-            onRejected: { promiseReturn.reject($0) },
-            onCanceled: { [weak promiseReturn] in promiseReturn?.cancel() }
-        )
-        promise2.subscribe(
-            queue: queue,
-            onResolved: { _ in resolve() },
-            onRejected: { promiseReturn.reject($0) },
-            onCanceled: { [weak promiseReturn] in promiseReturn?.cancel() }
-        )
-        
-        return promiseReturn
-    }
-    
-    public static func all<Value0, Value1, Value2, Value3, Failure0, Failure1, Failure2, Failure3>(
-        on queue: DispatchQueue = .global(),
-        _ promise0: Promise<Value0, Failure0>,
-        _ promise1: Promise<Value1, Failure1>,
-        _ promise2: Promise<Value2, Failure2>,
-        _ promise3: Promise<Value3, Failure3>
-    ) -> Promise<(Value0, Value1, Value2, Value3), Error> {
-        let promiseReturn = Promise<(Value0, Value1, Value2, Value3), Error>(queue: queue)
-        let resolve = {
-            guard
-                case .resolved(let value0) = promise0.state.capture({ $0 }),
-                case .resolved(let value1) = promise1.state.capture({ $0 }),
-                case .resolved(let value2) = promise2.state.capture({ $0 }),
-                case .resolved(let value3) = promise3.state.capture({ $0 })
-            else {
-                return
-            }
-            
-            promiseReturn.resolve((value0, value1, value2, value3))
-        }
-        
-        promise0.subscribe(
-            queue: queue,
-            onResolved: { _ in resolve() },
-            onRejected: { promiseReturn.reject($0) },
-            onCanceled: { [weak promiseReturn] in promiseReturn?.cancel() }
-        )
-        promise1.subscribe(
-            queue: queue,
-            onResolved: { _ in resolve() },
-            onRejected: { promiseReturn.reject($0) },
-            onCanceled: { [weak promiseReturn] in promiseReturn?.cancel() }
-        )
-        promise2.subscribe(
-            queue: queue,
-            onResolved: { _ in resolve() },
-            onRejected: { promiseReturn.reject($0) },
-            onCanceled: { [weak promiseReturn] in promiseReturn?.cancel() }
-        )
-        promise3.subscribe(
-            queue: queue,
-            onResolved: { _ in resolve() },
-            onRejected: { promiseReturn.reject($0) },
-            onCanceled: { [weak promiseReturn] in promiseReturn?.cancel() }
-        )
-        
-        return promiseReturn
-    }
-    
-    public static func all<Value0, Value1, Value2, Value3, Value4, Failure0, Failure1, Failure2, Failure3, Failure4>(
-        on queue: DispatchQueue = .global(),
-        _ promise0: Promise<Value0, Failure0>,
-        _ promise1: Promise<Value1, Failure1>,
-        _ promise2: Promise<Value2, Failure2>,
-        _ promise3: Promise<Value3, Failure3>,
-        _ promise4: Promise<Value4, Failure4>
-    ) -> Promise<(Value0, Value1, Value2, Value3, Value4), Error> {
-        let promiseReturn = Promise<(Value0, Value1, Value2, Value3, Value4), Error>(queue: queue)
-        let resolve = {
-            guard
-                case .resolved(let value0) = promise0.state.capture({ $0 }),
-                case .resolved(let value1) = promise1.state.capture({ $0 }),
-                case .resolved(let value2) = promise2.state.capture({ $0 }),
-                case .resolved(let value3) = promise3.state.capture({ $0 }),
-                case .resolved(let value4) = promise4.state.capture({ $0 })
-            else {
-                return
-            }
-            
-            promiseReturn.resolve((value0, value1, value2, value3, value4))
-        }
-        
-        promise0.subscribe(
-            queue: queue,
-            onResolved: { _ in resolve() },
-            onRejected: { promiseReturn.reject($0) },
-            onCanceled: { [weak promiseReturn] in promiseReturn?.cancel() }
-        )
-        promise1.subscribe(
-            queue: queue,
-            onResolved: { _ in resolve() },
-            onRejected: { promiseReturn.reject($0) },
-            onCanceled: { [weak promiseReturn] in promiseReturn?.cancel() }
-        )
-        promise2.subscribe(
-            queue: queue,
-            onResolved: { _ in resolve() },
-            onRejected: { promiseReturn.reject($0) },
-            onCanceled: { [weak promiseReturn] in promiseReturn?.cancel() }
-        )
-        promise3.subscribe(
-            queue: queue,
-            onResolved: { _ in resolve() },
-            onRejected: { promiseReturn.reject($0) },
-            onCanceled: { [weak promiseReturn] in promiseReturn?.cancel() }
-        )
-        promise4.subscribe(
-            queue: queue,
-            onResolved: { _ in resolve() },
-            onRejected: { promiseReturn.reject($0) },
-            onCanceled: { [weak promiseReturn] in promiseReturn?.cancel() }
-        )
         
         return promiseReturn
     }
 }
 
-extension Promise where
-    Value == Never,
-    Failure == Never
-{
-    public static func all<Value0, Value1>(
-        on queue: DispatchQueue = .global(),
-        _ promise0: Promise<Value0, Never>,
-        _ promise1: Promise<Value1, Never>
-    ) -> Promise<(Value0, Value1), Never> {
-        let promiseReturn = Promise<(Value0, Value1), Never>(queue: queue)
-        let resolve = {
-            guard
-                case .resolved(let value0) = promise0.state.capture({ $0 }),
-                case .resolved(let value1) = promise1.state.capture({ $0 })
-            else {
-                return
-            }
-            
-            promiseReturn.resolve((value0, value1))
-        }
-        
-        promise0.subscribe(
-            queue: queue,
-            onResolved: { _ in resolve() },
-            onRejected: { _ in },
-            onCanceled: { [weak promiseReturn] in promiseReturn?.cancel() }
-        )
-        promise1.subscribe(
-            queue: queue,
-            onResolved: { _ in resolve() },
-            onRejected: { _ in },
-            onCanceled: { [weak promiseReturn] in promiseReturn?.cancel() }
-        )
-        
-        return promiseReturn
-    }
-    
-    public static func all<Value0, Value1, Value2>(
-        on queue: DispatchQueue = .global(),
-        _ promise0: Promise<Value0, Never>,
-        _ promise1: Promise<Value1, Never>,
-        _ promise2: Promise<Value2, Never>
-    ) -> Promise<(Value0, Value1, Value2), Never> {
-        let promiseReturn = Promise<(Value0, Value1, Value2), Never>(queue: queue)
-        let resolve = {
-            guard
-                case .resolved(let value0) = promise0.state.capture({ $0 }),
-                case .resolved(let value1) = promise1.state.capture({ $0 }),
-                case .resolved(let value2) = promise2.state.capture({ $0 })
-            else {
-                return
-            }
-            
-            promiseReturn.resolve((value0, value1, value2))
-        }
-
-        promise0.subscribe(
-            queue: queue,
-            onResolved: { _ in resolve() },
-            onRejected: { _ in },
-            onCanceled: { [weak promiseReturn] in promiseReturn?.cancel() }
-        )
-        promise1.subscribe(
-            queue: queue,
-            onResolved: { _ in resolve() },
-            onRejected: { _ in },
-            onCanceled: { [weak promiseReturn] in promiseReturn?.cancel() }
-        )
-        promise2.subscribe(
-            queue: queue,
-            onResolved: { _ in resolve() },
-            onRejected: { _ in },
-            onCanceled: { [weak promiseReturn] in promiseReturn?.cancel() }
-        )
-        
-        return promiseReturn
-    }
-    
-    public static func all<Value0, Value1, Value2, Value3>(
-        on queue: DispatchQueue = .global(),
-        _ promise0: Promise<Value0, Never>,
-        _ promise1: Promise<Value1, Never>,
-        _ promise2: Promise<Value2, Never>,
-        _ promise3: Promise<Value3, Never>
-    ) -> Promise<(Value0, Value1, Value2, Value3), Never> {
-        let promiseReturn = Promise<(Value0, Value1, Value2, Value3), Never>(queue: queue)
-        let resolve = {
-            guard
-                case .resolved(let value0) = promise0.state.capture({ $0 }),
-                case .resolved(let value1) = promise1.state.capture({ $0 }),
-                case .resolved(let value2) = promise2.state.capture({ $0 }),
-                case .resolved(let value3) = promise3.state.capture({ $0 })
-            else {
-                return
-            }
-            
-            promiseReturn.resolve((value0, value1, value2, value3))
-        }
-        
-        promise0.subscribe(
-            queue: queue,
-            onResolved: { _ in resolve() },
-            onRejected: { _ in },
-            onCanceled: { [weak promiseReturn] in promiseReturn?.cancel() }
-        )
-        promise1.subscribe(
-            queue: queue,
-            onResolved: { _ in resolve() },
-            onRejected: { _ in },
-            onCanceled: { [weak promiseReturn] in promiseReturn?.cancel() }
-        )
-        promise2.subscribe(
-            queue: queue,
-            onResolved: { _ in resolve() },
-            onRejected: { _ in },
-            onCanceled: { [weak promiseReturn] in promiseReturn?.cancel() }
-        )
-        promise3.subscribe(
-            queue: queue,
-            onResolved: { _ in resolve() },
-            onRejected: { _ in },
-            onCanceled: { [weak promiseReturn] in promiseReturn?.cancel() }
-        )
-        
-        return promiseReturn
-    }
-    
-    public static func all<Value0, Value1, Value2, Value3, Value4>(
-        on queue: DispatchQueue = .global(),
-        _ promise0: Promise<Value0, Never>,
-        _ promise1: Promise<Value1, Never>,
-        _ promise2: Promise<Value2, Never>,
-        _ promise3: Promise<Value3, Never>,
-        _ promise4: Promise<Value4, Never>
-    ) -> Promise<(Value0, Value1, Value2, Value3, Value4), Never> {
-        let promiseReturn = Promise<(Value0, Value1, Value2, Value3, Value4), Never>(queue: queue)
-        let resolve = {
-            guard
-                case .resolved(let value0) = promise0.state.capture({ $0 }),
-                case .resolved(let value1) = promise1.state.capture({ $0 }),
-                case .resolved(let value2) = promise2.state.capture({ $0 }),
-                case .resolved(let value3) = promise3.state.capture({ $0 }),
-                case .resolved(let value4) = promise4.state.capture({ $0 })
-            else {
-                return
-            }
-            
-            promiseReturn.resolve((value0, value1, value2, value3, value4))
-        }
-        
-        promise0.subscribe(
-            queue: queue,
-            onResolved: { _ in resolve() },
-            onRejected: { _ in },
-            onCanceled: { [weak promiseReturn] in promiseReturn?.cancel() }
-        )
-        promise1.subscribe(
-            queue: queue,
-            onResolved: { _ in resolve() },
-            onRejected: { _ in },
-            onCanceled: { [weak promiseReturn] in promiseReturn?.cancel() }
-        )
-        promise2.subscribe(
-            queue: queue,
-            onResolved: { _ in resolve() },
-            onRejected: { _ in },
-            onCanceled: { [weak promiseReturn] in promiseReturn?.cancel() }
-        )
-        promise3.subscribe(
-            queue: queue,
-            onResolved: { _ in resolve() },
-            onRejected: { _ in },
-            onCanceled: { [weak promiseReturn] in promiseReturn?.cancel() }
-        )
-        promise4.subscribe(
-            queue: queue,
-            onResolved: { _ in resolve() },
-            onRejected: { _ in },
-            onCanceled: { [weak promiseReturn] in promiseReturn?.cancel() }
-        )
-        
-        return promiseReturn
+extension PromiseState {
+    fileprivate var resolved: Value? {
+        guard case .resolved(let value) = self else { return nil }
+        return value
     }
 }

--- a/Test/Concurrency/Promise/Composition/PromiseAllTest.swift
+++ b/Test/Concurrency/Promise/Composition/PromiseAllTest.swift
@@ -259,4 +259,106 @@ final class PromiseAllTest: XCTestCase {
         
         PromiseTest.expect(promise: promise, state: .rejected(PromiseTest.SampleError.one), timeout: .seconds(1))
     }
+    
+    func test__all_6() {
+        let promise =
+        Promise.all(
+            Promise.async {
+                10
+            },
+            Promise.async {
+                true
+            },
+            Promise.async {
+                "10"
+            },
+            Promise.async {
+                10
+            },
+            Promise.async {
+                true
+            },
+            Promise.async {
+                "10"
+            }
+        )
+        
+        PromiseTest.expect(promise: promise, state: .resolved({$0 == (10, true, "10", 10, true, "10")}), timeout: .seconds(1))
+    }
+    
+    func test__all_6_reject_1() {
+        let promise =
+        Promise.all(
+            Promise.async { () -> Int in
+                throw PromiseTest.SampleError.one
+            },
+            Promise.async {
+                true
+            },
+            Promise.async {
+                "10"
+            },
+            Promise.async {
+                10
+            },
+            Promise.async {
+                true
+            },
+            Promise.async {
+                "10"
+            }
+        )
+        
+        PromiseTest.expect(promise: promise, state: .rejected(PromiseTest.SampleError.one), timeout: .seconds(1))
+    }
+    
+    func test__all_6_cancel_1() {
+        let promise =
+        Promise.all(
+            Promise<Int, Error>.canceled(),
+            Promise.async {
+                true
+            },
+            Promise.async {
+                "10"
+            },
+            Promise.async {
+                10
+            },
+            Promise.async {
+                true
+            },
+            Promise.async {
+                "10"
+            }
+        )
+        
+        PromiseTest.expect(promise: promise, state: .canceled, timeout: .seconds(1))
+    }
+    
+    func test__all_same_6_reject_1() {
+        let promise =
+        Promise.all([
+            Promise.async { () -> Int in
+                throw PromiseTest.SampleError.one
+            },
+            Promise.async {
+                20
+            },
+            Promise.async {
+                30
+            },
+            Promise.async {
+                40
+            },
+            Promise.async {
+                50
+            },
+            Promise.async {
+                60
+            }
+        ])
+        
+        PromiseTest.expect(promise: promise, state: .rejected(PromiseTest.SampleError.one), timeout: .seconds(1))
+    }
 }

--- a/Test/Concurrency/Promise/Composition/PromiseAllTest.swift
+++ b/Test/Concurrency/Promise/Composition/PromiseAllTest.swift
@@ -39,7 +39,7 @@ final class PromiseAllTest: XCTestCase {
     
     func test__all_2_reject_1() {
         let promise =
-        Promise.all(
+        Promise.tryAll(
             Promise.async { () -> Int in
                 throw PromiseTest.SampleError.one
             },
@@ -53,7 +53,7 @@ final class PromiseAllTest: XCTestCase {
     
     func test__all_2_cancel_1() {
         let promise =
-        Promise.all(
+        Promise.tryAll(
             Promise<Int, Error>.canceled(),
             Promise.async {
                 true
@@ -82,7 +82,7 @@ final class PromiseAllTest: XCTestCase {
     
     func test__all_3_reject_1() {
         let promise =
-        Promise.all(
+        Promise.tryAll(
             Promise.async { () -> Int in
                 throw PromiseTest.SampleError.one
             },
@@ -99,7 +99,7 @@ final class PromiseAllTest: XCTestCase {
     
     func test__all_3_cancel_1() {
         let promise =
-        Promise.all(
+        Promise.tryAll(
             Promise<Int, Error>.canceled(),
             Promise.async {
                 true
@@ -134,7 +134,7 @@ final class PromiseAllTest: XCTestCase {
     
     func test__all_4_reject_1() {
         let promise =
-        Promise.all(
+        Promise.tryAll(
             Promise.async { () -> Int in
                 throw PromiseTest.SampleError.one
             },
@@ -154,7 +154,7 @@ final class PromiseAllTest: XCTestCase {
     
     func test__all_4_cancel_1() {
         let promise =
-        Promise.all(
+        Promise.tryAll(
             Promise<Int, Error>.canceled(),
             Promise.async {
                 true
@@ -195,7 +195,7 @@ final class PromiseAllTest: XCTestCase {
     
     func test__all_5_reject_1() {
         let promise =
-        Promise.all(
+        Promise.tryAll(
             Promise.async { () -> Int in
                 throw PromiseTest.SampleError.one
             },
@@ -218,7 +218,7 @@ final class PromiseAllTest: XCTestCase {
     
     func test__all_5_cancel_1() {
         let promise =
-        Promise.all(
+        Promise.tryAll(
             Promise<Int, Error>.canceled(),
             Promise.async {
                 true
@@ -288,7 +288,7 @@ final class PromiseAllTest: XCTestCase {
     
     func test__all_6_reject_1() {
         let promise =
-        Promise.all(
+        Promise.tryAll(
             Promise.async { () -> Int in
                 throw PromiseTest.SampleError.one
             },
@@ -314,7 +314,7 @@ final class PromiseAllTest: XCTestCase {
     
     func test__all_6_cancel_1() {
         let promise =
-        Promise.all(
+        Promise.tryAll(
             Promise<Int, Error>.canceled(),
             Promise.async {
                 true


### PR DESCRIPTION
### Changes
`Promise.all` has been improved using [Swift 5.9 Parameter Packs](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0393-parameter-packs.md). It can now handle any number of parameters without being limited by a fixed count.

Previously, `Promise.all` only supported up to five promises and had a separate method for cases where the promise's `Failure` was `Never`. With Parameter Packs, these have been unified into a single method.

When using `Promise.all` with parameters of type `[Promise<Value, Failure>]`(when using an array), the existing code has been retained.


### Example
```swift
Promise.all(
    p1, p2, p3, p4, p5, p6
)
```