### PR TITLE
fix: preserve Contract sync order

### DIFF
--- a/Source/Concurrency/Contract/Chain/ContractFilter.swift
+++ b/Source/Concurrency/Contract/Chain/ContractFilter.swift
@@ -61,13 +61,17 @@ extension Contract {
         schedule: ContractSchedule = .async,
         _ block: @escaping (Value) -> Promise<Result?, Never>
     ) -> Contract<Result, Failure> {
+        let sharesExplicitQueue = queue != nil
         let queue = queue ?? self.queue
         
         let contract = Contract<Result, Failure>(queue: queue)
         
         subscribe(
             queue: queue,
-            onResolved: schedule { value, finish in
+            onResolved: schedule.handler(
+                on: queue,
+                sharesExplicitQueue: sharesExplicitQueue
+            ) { value, finish in
                 let promise = block(value)
                 promise.subscribe(
                     queue: queue,
@@ -102,14 +106,21 @@ extension Contract {
         schedule: ContractSchedule = .async,
         _ block: @escaping (Value) -> Promise<Result, Never>?
     ) -> Contract<Result, Failure> {
+        let sharesExplicitQueue = queue != nil
         let queue = queue ?? self.queue
         
         let contract = Contract<Result, Failure>(queue: queue)
         
         subscribe(
             queue: queue,
-            onResolved: schedule { value, finish in
-                guard let promise = block(value) else { return }
+            onResolved: schedule.handler(
+                on: queue,
+                sharesExplicitQueue: sharesExplicitQueue
+            ) { value, finish in
+                guard let promise = block(value) else {
+                    finish()
+                    return
+                }
                 promise.subscribe(
                     queue: queue,
                     onResolved: {

--- a/Source/Concurrency/Contract/Chain/ContractRecover.swift
+++ b/Source/Concurrency/Contract/Chain/ContractRecover.swift
@@ -49,6 +49,7 @@ extension Contract {
         schedule: ContractSchedule = .async,
         _ block: @escaping (Failure) throws -> Promise<Value, ResultFailure>
     ) -> Contract<Value, Error> {
+        let sharesExplicitQueue = queue != nil
         let queue = queue ?? self.queue
         
         let contract = Contract<Value, Error>(queue: self.queue)
@@ -56,7 +57,10 @@ extension Contract {
         subscribe(
             queue: queue,
             onResolved: { value in contract.resolve(value) },
-            onRejected: schedule { error, finish in
+            onRejected: schedule.handler(
+                on: queue,
+                sharesExplicitQueue: sharesExplicitQueue
+            ) { error, finish in
                 do {
                     let promise = try block(error)
                     promise.subscribe(
@@ -124,6 +128,7 @@ extension Contract {
         schedule: ContractSchedule = .async,
         _ block: @escaping (Failure) -> Promise<Value, ResultFailure>
     ) -> Contract<Value, ResultFailure> {
+        let sharesExplicitQueue = queue != nil
         let queue = queue ?? self.queue
         
         let contract = Contract<Value, ResultFailure>(queue: self.queue)
@@ -131,7 +136,10 @@ extension Contract {
         subscribe(
             queue: queue,
             onResolved: { value in contract.resolve(value) },
-            onRejected: schedule { error, finish in
+            onRejected: schedule.handler(
+                on: queue,
+                sharesExplicitQueue: sharesExplicitQueue
+            ) { error, finish in
                 let promise = block(error)
                 promise.subscribe(
                     queue: queue,

--- a/Source/Concurrency/Contract/Chain/ContractThen.swift
+++ b/Source/Concurrency/Contract/Chain/ContractThen.swift
@@ -49,13 +49,17 @@ extension Contract {
         schedule: ContractSchedule = .async,
         _ block: @escaping (Value) throws -> Promise<Result, ResultFailure>
     ) -> Contract<Result, Error> {
+        let sharesExplicitQueue = queue != nil
         let queue = queue ?? self.queue
         
         let contract = Contract<Result, Error>(queue: self.queue)
         
         subscribe(
             queue: queue,
-            onResolved: schedule { value, finish in
+            onResolved: schedule.handler(
+                on: queue,
+                sharesExplicitQueue: sharesExplicitQueue
+            ) { value, finish in
                 do {
                     let promise = try block(value)
                     promise.subscribe(
@@ -124,13 +128,17 @@ extension Contract where Failure == Never {
         schedule: ContractSchedule = .async,
         _ block: @escaping (Value) -> Promise<Result, ResultFailure>
     ) -> Contract<Result, ResultFailure> {
+        let sharesExplicitQueue = queue != nil
         let queue = queue ?? self.queue
         
         let contract = Contract<Result, ResultFailure>(queue: self.queue)
         
         subscribe(
             queue: queue,
-            onResolved: schedule { value, finish in
+            onResolved: schedule.handler(
+                on: queue,
+                sharesExplicitQueue: sharesExplicitQueue
+            ) { value, finish in
                 let promise = block(value)
                 promise.subscribe(
                     queue: queue,

--- a/Source/Concurrency/Contract/Contract.swift
+++ b/Source/Concurrency/Contract/Contract.swift
@@ -36,11 +36,11 @@ extension Contract {
                 let subscribers = subscribers
                 
                 subscribers.forEach { subscriber in
-                    next.enter()
-                    current.notify(queue: subscriber.queue) {
-                        subscriber.onResolved(value)
-                        next.leave()
-                    }
+                    subscriber.onResolved.accept(
+                        value,
+                        after: current,
+                        tracking: next
+                    )
                 }
                 
                 executeGroup = next
@@ -56,11 +56,11 @@ extension Contract {
                 let subscribers = subscribers
                 
                 subscribers.forEach { subscriber in
-                    next.enter()
-                    current.notify(queue: subscriber.queue) {
-                        subscriber.onRejected(error)
-                        next.leave()
-                    }
+                    subscriber.onRejected.accept(
+                        error,
+                        after: current,
+                        tracking: next
+                    )
                 }
                 
                 executeGroup = next
@@ -87,14 +87,13 @@ extension Contract {
 
     func subscribe(
         queue: DispatchQueue,
-        onResolved: @escaping (Value) -> Void,
-        onRejected: @escaping (Failure) -> Void,
+        onResolved: ContractEventHandler<Value>,
+        onRejected: ContractEventHandler<Failure>,
         onCanceled: @escaping () -> Void
     ) {
         state.capture { state in
             if case .executing = state {
                 subscribers.append(ContractSubscriber(
-                    queue: queue,
                     onResolved: onResolved,
                     onRejected: onRejected
                 ))
@@ -109,6 +108,48 @@ extension Contract {
                 }
             }
         }
+    }
+
+    func subscribe(
+        queue: DispatchQueue,
+        onResolved: @escaping (Value) -> Void,
+        onRejected: @escaping (Failure) -> Void,
+        onCanceled: @escaping () -> Void
+    ) {
+        subscribe(
+            queue: queue,
+            onResolved: ContractEventHandler(on: queue, block: onResolved),
+            onRejected: ContractEventHandler(on: queue, block: onRejected),
+            onCanceled: onCanceled
+        )
+    }
+
+    func subscribe(
+        queue: DispatchQueue,
+        onResolved: ContractEventHandler<Value>,
+        onRejected: @escaping (Failure) -> Void,
+        onCanceled: @escaping () -> Void
+    ) {
+        subscribe(
+            queue: queue,
+            onResolved: onResolved,
+            onRejected: ContractEventHandler(on: queue, block: onRejected),
+            onCanceled: onCanceled
+        )
+    }
+
+    func subscribe(
+        queue: DispatchQueue,
+        onResolved: @escaping (Value) -> Void,
+        onRejected: ContractEventHandler<Failure>,
+        onCanceled: @escaping () -> Void
+    ) {
+        subscribe(
+            queue: queue,
+            onResolved: ContractEventHandler(on: queue, block: onResolved),
+            onRejected: onRejected,
+            onCanceled: onCanceled
+        )
     }
     
     func subscribe(
@@ -263,14 +304,52 @@ enum ContractState {
 }
 
 struct ContractSubscriber<Value, Failure: Error> {
-    let queue: DispatchQueue
-    let onResolved: (Value) -> Void
-    let onRejected: (Failure) -> Void
+    let onResolved: ContractEventHandler<Value>
+    let onRejected: ContractEventHandler<Failure>
 }
 
 struct ContractCancelSubscriber {
     let queue: DispatchQueue
     let onCanceled: () -> Void
+}
+
+struct ContractEventHandler<Value> {
+    private let onAccepted: (
+        Value,
+        DispatchGroup,
+        DispatchGroup
+    ) -> Void
+
+    init(
+        on queue: DispatchQueue,
+        block: @escaping (Value) -> Void
+    ) {
+        self.onAccepted = { value, previous, current in
+            current.enter()
+            previous.notify(queue: queue) {
+                block(value)
+                current.leave()
+            }
+        }
+    }
+
+    init(
+        onAccepted: @escaping (
+            Value,
+            DispatchGroup,
+            DispatchGroup
+        ) -> Void
+    ) {
+        self.onAccepted = onAccepted
+    }
+
+    func accept(
+        _ value: Value,
+        after previous: DispatchGroup,
+        tracking current: DispatchGroup
+    ) {
+        onAccepted(value, previous, current)
+    }
 }
 
 public final class ContractSchedule {
@@ -280,24 +359,37 @@ public final class ContractSchedule {
         self.mode = mode
     }
     
-    func callAsFunction<Value>(
+    func handler<Value>(
+        on queue: DispatchQueue,
+        sharesExplicitQueue: Bool,
         block: @escaping (
             Value,
             @escaping () -> Void
         ) -> Void
-    ) -> (Value) -> Void {
+    ) -> ContractEventHandler<Value> {
         switch mode {
         case .async:
-            return { value in
+            return ContractEventHandler(on: queue) { value in
                 block(value, {})
             }
-        case .sync(let next):
-            return { value in
-                next.mutate { promise in
-                    promise.then { _ in
-                        Promise { resolve, _ in
-                            block(value, { resolve(()) })
-                        }
+        case .sync(let coordinator):
+            guard sharesExplicitQueue else {
+                return ContractEventHandler(on: queue) { value in
+                    coordinator.enqueue(on: .global()) { finish in
+                        block(value, finish)
+                    }
+                }
+            }
+
+            let coordinator = ContractScheduleCoordinatorRegistry.shared.coordinator(
+                for: queue
+            )
+            return ContractEventHandler { value, previous, current in
+                current.enter()
+                coordinator.enqueue(on: queue) { finish in
+                    previous.notify(queue: queue) {
+                        block(value, finish)
+                        current.leave()
                     }
                 }
             }
@@ -309,11 +401,103 @@ public final class ContractSchedule {
     }
     
     public static var sync: ContractSchedule {
-        self.init(mode: .sync(next: Atomic(.resolved(()))))
+        self.init(mode: .sync(coordinator: ContractScheduleCoordinator()))
     }
     
     private enum Mode {
         case async
-        case sync(next: Atomic<Promise<Void, Never>>)
+        case sync(coordinator: ContractScheduleCoordinator)
+    }
+}
+
+final class ContractScheduleCoordinator {
+    private let tail = Atomic(Promise<Void, Never>.resolved(()))
+
+    func enqueue(
+        on queue: DispatchQueue,
+        block: @escaping (@escaping () -> Void) -> Void
+    ) {
+        let completion = Promise<Void, Never>.pending()
+        var previous: Promise<Void, Never>?
+
+        tail.mutate { tail in
+            previous = tail
+            return completion.promise
+        }
+
+        let finish = { [self] in
+            complete(completion)
+        }
+
+        previous?.subscribe(
+            on: queue,
+            onResolved: { _ in
+                block(finish)
+            },
+            onRejected: { _ in },
+            onCanceled: {
+                block(finish)
+            }
+        )
+    }
+
+    private func complete(
+        _ completion: PromisePending<Void, Never>
+    ) {
+        completion.resolve(())
+    }
+}
+
+final class ContractScheduleCoordinatorRegistry {
+    static let shared = ContractScheduleCoordinatorRegistry()
+
+    private let entries = Atomic<[Entry]>([])
+
+    private init() {}
+
+    func coordinator(
+        for queue: DispatchQueue
+    ) -> ContractScheduleCoordinator {
+        var result: ContractScheduleCoordinator?
+
+        entries.mutate { entries in
+            var entries = entries.filter {
+                $0.queue != nil && $0.coordinator != nil
+            }
+            if let coordinator = entries.first(where: {
+                $0.queue === queue
+            })?.coordinator {
+                result = coordinator
+            }
+            else {
+                let coordinator = ContractScheduleCoordinator()
+                entries.append(Entry(queue: queue, coordinator: coordinator))
+                result = coordinator
+            }
+            return entries
+        }
+
+        return result!
+    }
+
+    var activeCount: Int {
+        entries.mutate { entries in
+            entries.filter {
+                $0.queue != nil && $0.coordinator != nil
+            }
+        }.count
+    }
+
+    private final class Entry {
+        weak var queue: DispatchQueue?
+        weak var coordinator: ContractScheduleCoordinator?
+
+        init(
+            queue: DispatchQueue,
+            coordinator: ContractScheduleCoordinator
+        ) {
+            self.queue = queue
+            self.coordinator = coordinator
+        }
     }
 }

--- a/Test/Concurrency/Contract/Chain/ContractFilterTest.swift
+++ b/Test/Concurrency/Contract/Chain/ContractFilterTest.swift
@@ -178,4 +178,26 @@ final class ContractFilterTest: XCTestCase {
         
         XCTAssertEqual(actual, expect)
     }
+
+    func test__filter_optional_promise_schedule_sync_nil_finishes() {
+        let queue = DispatchQueue(label: "co.ab180.saby.contract-filter-test")
+        let contract = Contract<Int, Never>.executing()
+        let filtered = expectation(description: "second value filtered")
+
+        contract.contract
+            .filter(on: queue, schedule: .sync) { value -> Promise<Int, Never>? in
+                guard value != 1 else { return nil }
+                return .resolved(value)
+            }
+            .then { value in
+                if value == 2 {
+                    filtered.fulfill()
+                }
+            }
+
+        contract.resolve(1)
+        contract.resolve(2)
+
+        XCTAssertEqual(XCTWaiter().wait(for: [filtered], timeout: 1), .completed)
+    }
 }

--- a/Test/Concurrency/Contract/ContractScheduleTest.swift
+++ b/Test/Concurrency/Contract/ContractScheduleTest.swift
@@ -1,0 +1,546 @@
+//
+//  ContractScheduleTest.swift
+//  SabyConcurrencyTest
+//
+
+import XCTest
+@testable import SabyConcurrency
+
+final class ContractScheduleTest: XCTestCase {
+    func test__sync_explicit_queue_accepts_cross_contract_work_in_resolve_order() {
+        let queue = DispatchQueue(label: "co.ab180.saby.contract-schedule-test")
+        let contractA = Contract<String, Never>.executing()
+        let contractB = Contract<String, Never>.executing()
+        let promiseA1 = Promise<Void, Never>.pending()
+        let promiseA2 = Promise<Void, Never>.pending()
+        let promiseB1 = Promise<Void, Never>.pending()
+        let startedA1 = expectation(description: "A1 started")
+        let startedA2 = expectation(description: "A2 started")
+        let startedB1 = expectation(description: "B1 started")
+        let initialQueueDrained = expectation(description: "initial queue drained")
+        let started = Atomic<[String]>([])
+
+        contractA.contract.then(on: queue, schedule: .sync) { value in
+            started.mutate { $0 + [value] }
+            switch value {
+            case "A1":
+                startedA1.fulfill()
+                return promiseA1.promise
+            case "A2":
+                startedA2.fulfill()
+                return promiseA2.promise
+            default:
+                XCTFail("Unexpected value: \(value)")
+                return .resolved(())
+            }
+        }
+        contractB.contract.then(on: queue, schedule: .sync) { value in
+            started.mutate { $0 + [value] }
+            startedB1.fulfill()
+            return promiseB1.promise
+        }
+
+        contractA.resolve("A1")
+        contractA.resolve("A2")
+        contractB.resolve("B1")
+        queue.async {
+            initialQueueDrained.fulfill()
+        }
+
+        XCTAssertEqual(
+            XCTWaiter().wait(for: [startedA1, initialQueueDrained], timeout: 1),
+            .completed
+        )
+        XCTAssertEqual(started.capture { $0 }, ["A1"])
+
+        promiseA1.resolve(())
+        XCTAssertEqual(XCTWaiter().wait(for: [startedA2], timeout: 1), .completed)
+        XCTAssertEqual(started.capture { $0 }, ["A1", "A2"])
+
+        promiseA2.resolve(())
+        XCTAssertEqual(XCTWaiter().wait(for: [startedB1], timeout: 1), .completed)
+        XCTAssertEqual(started.capture { $0 }, ["A1", "A2", "B1"])
+        promiseB1.resolve(())
+    }
+
+    func test__sync_different_explicit_queues_execute_independently() {
+        let label = "co.ab180.saby.contract-schedule-test.independent"
+        let queueA = DispatchQueue(label: label)
+        let queueB = DispatchQueue(label: label)
+        let contractA = Contract<Void, Never>.executing()
+        let contractB = Contract<Void, Never>.executing()
+        let promiseA = Promise<Void, Never>.pending()
+        let startedA = expectation(description: "A started")
+        let startedB = expectation(description: "B started")
+
+        contractA.contract.then(on: queueA, schedule: .sync) {
+            startedA.fulfill()
+            return promiseA.promise
+        }
+        contractB.contract.then(on: queueB, schedule: .sync) {
+            startedB.fulfill()
+            return Promise<Void, Never>.resolved(())
+        }
+
+        contractA.resolve(())
+        contractB.resolve(())
+
+        XCTAssertEqual(
+            XCTWaiter().wait(for: [startedA, startedB], timeout: 1),
+            .completed
+        )
+        promiseA.resolve(())
+    }
+
+    func test__sync_omitted_queue_keeps_contracts_independent() {
+        let sharedQueue = DispatchQueue(
+            label: "co.ab180.saby.contract-schedule-test.omitted"
+        )
+        let contractA = Contract<Void, Never>.executing(on: sharedQueue)
+        let contractB = Contract<Void, Never>.executing(on: sharedQueue)
+        let promiseA = Promise<Void, Never>.pending()
+        let startedA = expectation(description: "A started")
+        let startedB = expectation(description: "B started")
+
+        contractA.contract.then(schedule: .sync) {
+            startedA.fulfill()
+            return promiseA.promise
+        }
+        contractB.contract.then(schedule: .sync) {
+            startedB.fulfill()
+            return Promise<Void, Never>.resolved(())
+        }
+
+        contractA.resolve(())
+        contractB.resolve(())
+
+        XCTAssertEqual(
+            XCTWaiter().wait(for: [startedA, startedB], timeout: 1),
+            .completed
+        )
+        promiseA.resolve(())
+    }
+
+    func test__sync_omitted_queue_preserves_legacy_callback_queue() {
+        let queue = DispatchQueue(
+            label: "co.ab180.saby.contract-schedule-test.legacy-affinity"
+        )
+        let key = DispatchSpecificKey<String>()
+        queue.setSpecific(key: key, value: "contract-queue")
+        let contract = Contract<Void, Never>.executing(on: queue)
+        let executed = expectation(description: "legacy callback executed")
+
+        contract.contract.then(schedule: .sync) {
+            XCTAssertNil(DispatchQueue.getSpecific(key: key))
+            executed.fulfill()
+            return Promise<Void, Never>.resolved(())
+        }
+
+        contract.resolve(())
+
+        XCTAssertEqual(
+            XCTWaiter().wait(for: [executed], timeout: 1),
+            .completed
+        )
+    }
+
+    func test__async_explicit_queue_does_not_wait_for_previous_promise() {
+        let queue = DispatchQueue(label: "co.ab180.saby.contract-schedule-test.async")
+        let contractA = Contract<Void, Never>.executing()
+        let contractB = Contract<Void, Never>.executing()
+        let promiseA = Promise<Void, Never>.pending()
+        let startedA = expectation(description: "A started")
+        let startedB = expectation(description: "B started")
+
+        contractA.contract.then(on: queue, schedule: .async) {
+            startedA.fulfill()
+            return promiseA.promise
+        }
+        contractB.contract.then(on: queue, schedule: .async) {
+            startedB.fulfill()
+            return Promise<Void, Never>.resolved(())
+        }
+
+        contractA.resolve(())
+        contractB.resolve(())
+
+        XCTAssertEqual(
+            XCTWaiter().wait(for: [startedA, startedB], timeout: 1),
+            .completed
+        )
+        promiseA.resolve(())
+    }
+
+    func test__sync_explicit_queue_executes_block_on_requested_queue() {
+        let queue = DispatchQueue(
+            label: "co.ab180.saby.contract-schedule-test.affinity"
+        )
+        let key = DispatchSpecificKey<String>()
+        let value = "requested-queue"
+        queue.setSpecific(key: key, value: value)
+        let contract = Contract<Void, Never>.executing()
+        let executed = expectation(description: "executed on requested queue")
+
+        contract.contract.then(on: queue, schedule: .sync) {
+            XCTAssertEqual(DispatchQueue.getSpecific(key: key), value)
+            executed.fulfill()
+            return Promise<Void, Never>.resolved(())
+        }
+
+        contract.resolve(())
+
+        XCTAssertEqual(
+            XCTWaiter().wait(for: [executed], timeout: 1),
+            .completed
+        )
+    }
+
+    func test__sync_continues_after_all_terminal_paths() {
+        let queue = DispatchQueue(
+            label: "co.ab180.saby.contract-schedule-test.terminal"
+        )
+        let resolved = Contract<Void, Never>.executing()
+        let recovered = Contract<Void, ScheduleTestError>.executing()
+        let rejected = Contract<Void, Never>.executing()
+        let canceled = Contract<Void, Never>.executing()
+        let thrown = Contract<Void, Error>.executing()
+        let filtered = Contract<Void, Never>.executing()
+        let sentinel = Contract<Void, Never>.executing()
+        let completed = expectation(description: "all terminal paths completed")
+        let initialQueueDrained = expectation(description: "initial queue drained")
+        let pending = Promise<Void, Never>.pending()
+        var started = [String]()
+
+        resolved.contract.then(on: queue, schedule: .sync) {
+            started.append("resolved")
+            return pending.promise
+        }
+        recovered.contract.recover(on: queue, schedule: .sync) { _ in
+            started.append("recovered")
+            return Promise<Void, Never>.resolved(())
+        }
+        rejected.contract.then(on: queue, schedule: .sync) {
+            started.append("rejected")
+            return Promise<Void, Error>.rejected(ScheduleTestError.failed)
+        }
+        canceled.contract.then(on: queue, schedule: .sync) {
+            started.append("canceled")
+            return Promise<Void, Never>.canceled()
+        }
+        thrown.contract.then(on: queue, schedule: .sync) { _ -> Promise<Void, Never> in
+            started.append("thrown")
+            throw ScheduleTestError.failed
+        }
+        _ = filtered.contract.filter(on: queue, schedule: .sync) {
+            _ -> Promise<Void, Never>? in
+            started.append("filtered")
+            return nil
+        }
+        sentinel.contract.then(on: queue, schedule: .sync) {
+            started.append("sentinel")
+            completed.fulfill()
+            return Promise<Void, Never>.resolved(())
+        }
+
+        resolved.resolve(())
+        recovered.reject(.failed)
+        rejected.resolve(())
+        canceled.resolve(())
+        thrown.resolve(())
+        filtered.resolve(())
+        sentinel.resolve(())
+        queue.async {
+            initialQueueDrained.fulfill()
+        }
+
+        XCTAssertEqual(
+            XCTWaiter().wait(for: [initialQueueDrained], timeout: 1),
+            .completed
+        )
+        XCTAssertEqual(started, ["resolved"])
+        pending.resolve(())
+
+        XCTAssertEqual(
+            XCTWaiter().wait(for: [completed], timeout: 1),
+            .completed
+        )
+        XCTAssertEqual(
+            started,
+            [
+                "resolved",
+                "recovered",
+                "rejected",
+                "canceled",
+                "thrown",
+                "filtered",
+                "sentinel",
+            ]
+        )
+    }
+
+    func test__sync_allows_reentrant_resolve_on_same_queue() {
+        let queue = DispatchQueue(
+            label: "co.ab180.saby.contract-schedule-test.reentrant"
+        )
+        let contract = Contract<Int, Never>.executing()
+        let completed = expectation(description: "reentrant values completed")
+        var started = [Int]()
+
+        contract.contract.then(on: queue, schedule: .sync) { value in
+            started.append(value)
+            if value < 100 {
+                contract.resolve(value + 1)
+            }
+            else {
+                completed.fulfill()
+            }
+            return Promise<Void, Never>.resolved(())
+        }
+
+        contract.resolve(0)
+
+        XCTAssertEqual(
+            XCTWaiter().wait(for: [completed], timeout: 2),
+            .completed
+        )
+        XCTAssertEqual(started, Array(0...100))
+    }
+
+    func test__sync_multiple_subscribers_deliver_each_event_once_in_order() {
+        let queue = DispatchQueue(
+            label: "co.ab180.saby.contract-schedule-test.subscribers"
+        )
+        let contract = Contract<Int, Never>.executing()
+        let completed = expectation(description: "all subscriber events completed")
+        let eventCount = 500
+        var actual = [String]()
+
+        contract.contract.then(on: queue, schedule: .sync) { value in
+            actual.append("A\(value)")
+            return Promise<Void, Never>.resolved(())
+        }
+        contract.contract.then(on: queue, schedule: .sync) { value in
+            actual.append("B\(value)")
+            if actual.count == eventCount * 2 {
+                completed.fulfill()
+            }
+            return Promise<Void, Never>.resolved(())
+        }
+
+        (0..<eventCount).forEach(contract.resolve)
+
+        XCTAssertEqual(
+            XCTWaiter().wait(for: [completed], timeout: 5),
+            .completed
+        )
+        XCTAssertEqual(
+            actual,
+            (0..<eventCount).flatMap { ["A\($0)", "B\($0)"] }
+        )
+    }
+
+    func test__sync_cross_contract_fifo_stress_exceeds_ten_thousand_events() {
+        let queue = DispatchQueue(
+            label: "co.ab180.saby.contract-schedule-test.stress"
+        )
+        let contractA = Contract<Int, Never>.executing()
+        let contractB = Contract<Int, Never>.executing()
+        let completed = expectation(description: "stress events completed")
+        let eventCount = 10_001
+        var actual = [Int]()
+
+        let record: (Int) -> Promise<Void, Never> = { value in
+            actual.append(value)
+            if actual.count == eventCount {
+                completed.fulfill()
+            }
+            return .resolved(())
+        }
+        contractA.contract.then(on: queue, schedule: .sync, record)
+        contractB.contract.then(on: queue, schedule: .sync, record)
+
+        for value in 0..<eventCount {
+            if value.isMultiple(of: 2) {
+                contractA.resolve(value)
+            }
+            else {
+                contractB.resolve(value)
+            }
+        }
+
+        XCTAssertEqual(
+            XCTWaiter().wait(for: [completed], timeout: 30),
+            .completed
+        )
+        XCTAssertEqual(actual, Array(0..<eventCount))
+    }
+
+    func test__sync_concurrent_producers_do_not_overlap_or_lose_events() {
+        let queue = DispatchQueue(
+            label: "co.ab180.saby.contract-schedule-test.concurrent"
+        )
+        let producerQueue = DispatchQueue(
+            label: "co.ab180.saby.contract-schedule-test.producers",
+            attributes: .concurrent
+        )
+        let contractA = Contract<Int, Never>.executing()
+        let contractB = Contract<Int, Never>.executing()
+        let completed = expectation(description: "concurrent events completed")
+        let eventCount = 2_001
+        let activeCount = Atomic(0)
+        let overlapped = Atomic(false)
+        let received = Atomic<Set<Int>>([])
+
+        let record: (Int) -> Promise<Void, Never> = { value in
+            if activeCount.mutate({ $0 + 1 }) != 1 {
+                overlapped.mutate { _ in true }
+            }
+            let receivedCount = received.mutate { received in
+                var received = received
+                received.insert(value)
+                return received
+            }.count
+            activeCount.mutate { $0 - 1 }
+            if receivedCount == eventCount {
+                completed.fulfill()
+            }
+            return .resolved(())
+        }
+        contractA.contract.then(on: queue, schedule: .sync, record)
+        contractB.contract.then(on: queue, schedule: .sync, record)
+
+        for value in 0..<eventCount {
+            producerQueue.async {
+                if value.isMultiple(of: 2) {
+                    contractA.resolve(value)
+                }
+                else {
+                    contractB.resolve(value)
+                }
+            }
+        }
+
+        XCTAssertEqual(
+            XCTWaiter().wait(for: [completed], timeout: 10),
+            .completed
+        )
+        XCTAssertFalse(overlapped.capture { $0 })
+        XCTAssertEqual(received.capture { $0 }, Set(0..<eventCount))
+    }
+
+    func test__registry_keeps_coordinator_alive_while_work_is_pending() {
+        let queue = DispatchQueue(
+            label: "co.ab180.saby.contract-schedule-test.active-lifetime"
+        )
+        let registry = ContractScheduleCoordinatorRegistry.shared
+        let pending = Promise<Void, Never>.pending()
+        let firstStarted = expectation(description: "first work started")
+        let initialQueueDrained = expectation(description: "initial queue drained")
+        let secondStarted = expectation(description: "second work started")
+        let secondQueueDrained = expectation(description: "second queue drained")
+        let didStartSecond = Atomic(false)
+        weak var weakCoordinator: ContractScheduleCoordinator?
+        var first: ContractExecuting<Void, Never>? = Contract.executing()
+        var firstOutput: Contract<Void, Never>? = first?.contract.then(
+            on: queue,
+            schedule: .sync
+        ) {
+            firstStarted.fulfill()
+            return pending.promise
+        }
+
+        XCTAssertNotNil(firstOutput)
+        weakCoordinator = registry.coordinator(for: queue)
+        first?.resolve(())
+        queue.async {
+            initialQueueDrained.fulfill()
+        }
+        XCTAssertEqual(
+            XCTWaiter().wait(
+                for: [firstStarted, initialQueueDrained],
+                timeout: 1
+            ),
+            .completed
+        )
+
+        first = nil
+        XCTAssertNotNil(weakCoordinator)
+
+        let second = Contract<Void, Never>.executing()
+        second.contract.then(on: queue, schedule: .sync) {
+            didStartSecond.mutate { _ in true }
+            secondStarted.fulfill()
+            return Promise<Void, Never>.resolved(())
+        }
+        second.resolve(())
+        queue.async {
+            secondQueueDrained.fulfill()
+        }
+
+        XCTAssertEqual(
+            XCTWaiter().wait(for: [secondQueueDrained], timeout: 1),
+            .completed
+        )
+        XCTAssertFalse(didStartSecond.capture { $0 })
+
+        pending.resolve(())
+        XCTAssertEqual(
+            XCTWaiter().wait(for: [secondStarted], timeout: 1),
+            .completed
+        )
+        firstOutput = nil
+    }
+
+    func test__registry_releases_queue_coordinator_and_contracts() {
+        let registry = ContractScheduleCoordinatorRegistry.shared
+        let initialCount = registry.activeCount
+        weak var weakQueue: DispatchQueue?
+        weak var weakCoordinator: ContractScheduleCoordinator?
+        weak var weakInput: Contract<Void, Never>?
+        weak var weakOutput: Contract<Void, Never>?
+
+        autoreleasepool {
+            var queue: DispatchQueue? = DispatchQueue(
+                label: "co.ab180.saby.contract-schedule-test.release"
+            )
+            var input: ContractExecuting<Void, Never>? = Contract.executing()
+            var output: Contract<Void, Never>? = input?.contract.then(
+                on: queue!,
+                schedule: .sync
+            ) {
+                Promise<Void, Never>.resolved(())
+            }
+
+            weakQueue = queue
+            weakInput = input?.contract
+            weakOutput = output
+            weakCoordinator = registry.coordinator(for: queue!)
+
+            let completed = expectation(description: "release work completed")
+            output?.subscribe(
+                onResolved: { _ in completed.fulfill() },
+                onRejected: { _ in },
+                onCanceled: {}
+            )
+            input?.resolve(())
+            XCTAssertEqual(
+                XCTWaiter().wait(for: [completed], timeout: 1),
+                .completed
+            )
+
+            output = nil
+            input = nil
+            queue = nil
+        }
+
+        XCTAssertNil(weakOutput)
+        XCTAssertNil(weakInput)
+        XCTAssertNil(weakCoordinator)
+        XCTAssertNil(weakQueue)
+        XCTAssertEqual(registry.activeCount, initialCount)
+    }
+}
+
+private enum ScheduleTestError: Error {
+    case failed
+}


### PR DESCRIPTION
## 요약
- Contract 이벤트가 접수되는 시점에 공유 선입선출(FIFO) 순번을 예약합니다.
- 동일한 `DispatchQueue` 객체를 명시적으로 지정한 `.sync` 작업만 실행 순서를 공유합니다.
- `queue == nil`과 `.async`의 기존 동작을 유지하고 선택적 Promise 필터가 `nil`을 반환하는 경로를 정상 종료합니다.
- 큐와 조정자를 약하게 참조하며 활성 작업이 끝날 때까지 필요한 수명만 유지합니다.

## 변경 전후

| 항목 | 변경 전 | 변경 후 |
| --- | --- | --- |
| Contract 간 실행 순서 | 각 Contract의 콜백이 시작된 뒤 개별 `.sync` 대기열에 작업을 등록했습니다. 따라서 A1, A2, B1 순서로 접수해도 A1, B1, A2 순서로 시작할 수 있었습니다. | 동일한 `DispatchQueue` 객체를 명시적으로 지정한 Contract는 `resolve` 또는 `reject` 접수 시 하나의 공유 선입선출 대기열에 순번을 예약합니다. |
| 대기 중인 Promise | 대기 중인 Promise는 해당 Contract의 개별 스케줄만 차단하므로 같은 큐의 다른 Contract가 먼저 실행될 수 있었습니다. | 앞 Promise가 `resolve`, `reject`, `cancel`되거나 사용자 block이 예외를 던진 뒤에만 다음 공유 작업을 시작합니다. |
| 콜백 실행 큐 | 큐를 명시적으로 전달해도 `.sync` block은 내부 전역 Promise 큐를 거쳐 실행될 수 있었습니다. | 큐를 명시적으로 지정한 `.sync` block은 해당 큐에서 실행됩니다. |
| 큐 격리 | 실행 순서가 각 스케줄 또는 Contract 콜백 경로별로 사실상 분리되었습니다. | 동일한 큐 객체만 실행 순서를 공유합니다. `label`이 같더라도 서로 다른 큐 객체는 독립적으로 실행됩니다. |
| 선택적 Promise 필터 | `nil`을 반환하면 `finish()`를 호출하지 않아 남은 `.sync` 대기열이 멈출 수 있었습니다. | `nil` 반환 경로에서도 `finish()`를 호출해 다음 작업이 계속 진행됩니다. |
| 수명 관리 | 큐 단위의 공유 레지스트리가 없었습니다. | 레지스트리는 큐와 조정자를 약하게 참조하고, 활성 작업은 종료될 때까지만 조정자를 유지합니다. |

## 호환성

공개 호출 형태는 변경되지 않습니다. 기존 `.async` 호출, 큐를 명시적으로 지정하지 않은 `.sync` 호출, 서로 다른 큐 객체를 사용하는 호출은 이전 동작을 유지합니다. 의도적인 동작 변경은 동일한 `DispatchQueue` 객체와 `.sync`를 함께 사용하는 Promise 기반 `then`, `filter`, `recover` 체인에 한정됩니다.

영구적으로 `pending` 상태에 머무는 Promise는 해당 큐를 공유하는 모든 `.sync` Contract를 차단합니다. 독립 실행이 필요하면 별도의 큐 객체 또는 `.async`를 사용해야 합니다.

## 검증
- `ContractScheduleTest`: 13건 통과
- `ContractThenTest`: 21건 통과
- `ContractFilterTest`: 10건 통과
- `ContractRecoverTest`: 5건 통과
- `swift test --parallel`: 343건 통과
- 스레드 안정성 검사(Thread Sanitizer) `ContractScheduleTest`: 13건 통과