### PR TITLE
feat(AppleStorage): CoreData Set 저장소 추가

### DIFF
--- a/Source/AppleStorage/Alias/SetStorageProtocol.swift
+++ b/Source/AppleStorage/Alias/SetStorageProtocol.swift
@@ -1,0 +1,11 @@
+//
+//  SetStorageProtocol.swift
+//  SabyAppleStorage
+//
+
+import Foundation
+
+extension SetStorage {
+    public typealias SelfProtocol = SetStorage<Self.Value>
+    public typealias AnyProtocol = any SetStorage<Self.Value>
+}

--- a/Source/AppleStorage/Implement/CoreDataSetStorage.swift
+++ b/Source/AppleStorage/Implement/CoreDataSetStorage.swift
@@ -10,6 +10,8 @@ import SabyJSON
 import SabySize
 
 private let STORAGE_VERSION = "Version1"
+private let STORAGE_ENCODING_VERSION_KEY = "SabyCoreDataSetStorageEncodingVersion"
+private let STORAGE_ENCODING_VERSION = 1
 
 public final class CoreDataSetStorage<Value: Codable & Hashable>: SetStorage {
     typealias Context = NSManagedObjectContext
@@ -55,17 +57,19 @@ extension CoreDataSetStorage {
 
             try context.executeSetStorageDelete(self.createAnyRequest())
 
-            guard !encodedValues.isEmpty else { return }
+            if !encodedValues.isEmpty {
+                let insertRequest = self.createInsertRequest(encodedValues: encodedValues)
+                insertRequest.resultType = .statusOnly
 
-            let insertRequest = self.createInsertRequest(encodedValues: encodedValues)
-            insertRequest.resultType = .statusOnly
-
-            guard
-                let result = try context.execute(insertRequest) as? NSBatchInsertResult,
-                result.result as? Bool == true
-            else {
-                throw CoreDataSetStorageError.batchInsertFailed
+                guard
+                    let result = try context.execute(insertRequest) as? NSBatchInsertResult,
+                    result.result as? Bool == true
+                else {
+                    throw CoreDataSetStorageError.batchInsertFailed
+                }
             }
+
+            try context.markSetStorageEncodingCurrent()
         }
     }
 
@@ -90,13 +94,33 @@ extension CoreDataSetStorage {
             let data = try self.encoder.encode(value)
             let request = self.createContainsRequest(data: data)
 
-            return try context.fetch(request).isEmpty == false
+            if try context.fetch(request).isEmpty == false {
+                return true
+            }
+
+            guard try context.isSetStorageEncodingCurrent() == false else {
+                return false
+            }
+
+            let dictionaries = try context.fetch(self.createDataRequest())
+            for dictionary in dictionaries {
+                guard let legacyData = dictionary["data"] as? Data else {
+                    throw CoreDataSetStorageError.requestResultNotFound
+                }
+
+                if try self.decoder.decode(Value.self, from: legacyData) == value {
+                    return true
+                }
+            }
+
+            return false
         }
     }
 
     public func clear() -> Promise<Void, Error> {
         execute { context in
             try context.executeSetStorageDelete(self.createAnyRequest())
+            try context.markSetStorageEncodingCurrent()
         }
     }
 }
@@ -215,6 +239,38 @@ extension CoreDataSetStorage {
 }
 
 private extension NSManagedObjectContext {
+    func isSetStorageEncodingCurrent() throws -> Bool {
+        let metadata = try setStorageMetadata()
+        let version = metadata.values[STORAGE_ENCODING_VERSION_KEY] as? NSNumber
+
+        return version?.intValue == STORAGE_ENCODING_VERSION
+    }
+
+    func markSetStorageEncodingCurrent() throws {
+        var metadata = try setStorageMetadata()
+        metadata.values[STORAGE_ENCODING_VERSION_KEY] = STORAGE_ENCODING_VERSION
+        metadata.coordinator.setMetadata(metadata.values, for: metadata.store)
+    }
+
+    func setStorageMetadata() throws -> (
+        coordinator: NSPersistentStoreCoordinator,
+        store: NSPersistentStore,
+        values: [String: Any]
+    ) {
+        guard
+            let coordinator = persistentStoreCoordinator,
+            let store = coordinator.persistentStores.first
+        else {
+            throw CoreDataSetStorageError.persistentStoreNotFound
+        }
+
+        return (
+            coordinator,
+            store,
+            coordinator.metadata(for: store)
+        )
+    }
+
     func executeSetStorageDelete(
         _ request: NSFetchRequest<any NSFetchRequestResult>
     ) throws {
@@ -273,6 +329,7 @@ private extension NSManagedObjectContext {
 public enum CoreDataSetStorageError: Error {
     case batchDeleteFailed
     case batchInsertFailed
+    case persistentStoreNotFound
     case requestResultNotFound
 }
 

--- a/Source/AppleStorage/Implement/CoreDataSetStorage.swift
+++ b/Source/AppleStorage/Implement/CoreDataSetStorage.swift
@@ -1,0 +1,298 @@
+//
+//  CoreDataSetStorage.swift
+//  SabyAppleStorage
+//
+
+import CoreData
+
+import SabyConcurrency
+import SabyJSON
+import SabySize
+
+private let STORAGE_VERSION = "Version1"
+
+public final class CoreDataSetStorage<Value: Codable & Hashable>: SetStorage {
+    typealias Context = NSManagedObjectContext
+
+    let entity: NSEntityDescription
+
+    let contextLoad: () -> Promise<Context, Error>
+    let contextPromise: Atomic<Promise<Context, Error>>
+
+    let encoder = JSONEncoder.acceptingNonConfirmingFloat()
+    let decoder = JSONDecoder.acceptingNonConfirmingFloat()
+
+    public init(
+        directoryURL: URL,
+        storageName: String,
+        migration: @escaping () -> Promise<Void, Error>
+    ) {
+        let schema = SabyCoreDataSetStorageSchema()
+
+        self.entity = schema.entity
+        self.contextLoad = {
+            Context.loadSetStorage(
+                directoryURL: directoryURL,
+                storageName: storageName,
+                migration: migration,
+                model: schema.model
+            )
+        }
+        self.contextPromise = Atomic(contextLoad())
+    }
+}
+
+extension CoreDataSetStorage {
+    public func set(_ values: Set<Value>) -> Promise<Void, Error> {
+        execute { context in
+            let encodedValues = try values.map { value -> Data in
+                try self.encoder.encode(value)
+            }
+
+            try context.executeSetStorageDelete(self.createAnyRequest())
+
+            guard !encodedValues.isEmpty else { return }
+
+            let insertRequest = self.createInsertRequest(encodedValues: encodedValues)
+            insertRequest.resultType = .statusOnly
+
+            guard
+                let result = try context.execute(insertRequest) as? NSBatchInsertResult,
+                result.result as? Bool == true
+            else {
+                throw CoreDataSetStorageError.batchInsertFailed
+            }
+        }
+    }
+
+    public func get() -> Promise<Set<Value>, Error> {
+        execute { context in
+            let dictionaries = try context.fetch(self.createDataRequest())
+            var values = Set<Value>(minimumCapacity: dictionaries.count)
+
+            for dictionary in dictionaries {
+                guard let data = dictionary["data"] as? Data else {
+                    throw CoreDataSetStorageError.requestResultNotFound
+                }
+                values.insert(try self.decoder.decode(Value.self, from: data))
+            }
+
+            return values
+        }
+    }
+
+    public func clear() -> Promise<Void, Error> {
+        execute { context in
+            try context.executeSetStorageDelete(self.createAnyRequest())
+        }
+    }
+}
+
+extension CoreDataSetStorage {
+    public func count() -> Promise<Int, Error> {
+        execute { context in
+            try context.count(for: self.createAnyRequest())
+        }
+    }
+
+    public func size() -> Promise<Volume, Error> {
+        execute { context in
+            let result = try context.fetch(self.createSizeRequest())
+            let byte = result.first?["result"] as? NSNumber ?? 0
+
+            return Volume.byte(byte.doubleValue)
+        }
+    }
+}
+
+extension CoreDataSetStorage {
+    fileprivate func createInsertRequest(encodedValues: [Data]) -> NSBatchInsertRequest {
+        if #available(iOS 14.0, macOS 11.0, macCatalyst 14.0, tvOS 14.0, watchOS 7.0, *) {
+            var index = 0
+
+            return NSBatchInsertRequest(
+                entity: entity,
+                dictionaryHandler: { dictionary in
+                    guard index < encodedValues.count else { return true }
+
+                    let data = encodedValues[index]
+                    dictionary["data"] = data
+                    dictionary["byte"] = data.count
+                    index += 1
+
+                    return false
+                }
+            )
+        } else {
+            let dictionaries = encodedValues.map { data in
+                [
+                    "data": data,
+                    "byte": data.count
+                ] as [String: Any]
+            }
+
+            return NSBatchInsertRequest(entity: entity, objects: dictionaries)
+        }
+    }
+
+    fileprivate func createAnyRequest() -> NSFetchRequest<any NSFetchRequestResult> {
+        let request = NSFetchRequest<any NSFetchRequestResult>()
+        request.entity = entity
+
+        return request
+    }
+
+    fileprivate func createDataRequest() -> NSFetchRequest<NSDictionary> {
+        let request = NSFetchRequest<NSDictionary>()
+        request.entity = entity
+        request.propertiesToFetch = ["data"]
+        request.resultType = .dictionaryResultType
+
+        return request
+    }
+
+    fileprivate func createSizeRequest() -> NSFetchRequest<NSDictionary> {
+        let byteExpression = NSExpression(forKeyPath: \SabyCoreDataSetStorageItemVersion1.byte)
+        let sumExpression = NSExpression(forFunction: "sum:", arguments: [byteExpression])
+        let sumDescription = NSExpressionDescription()
+        sumDescription.expression = sumExpression
+        sumDescription.name = "result"
+        sumDescription.expressionResultType = .integer64AttributeType
+
+        let request = NSFetchRequest<NSDictionary>()
+        request.entity = entity
+        request.propertiesToFetch = [sumDescription]
+        request.resultType = .dictionaryResultType
+
+        return request
+    }
+}
+
+extension CoreDataSetStorage {
+    fileprivate func execute<Result>(
+        block: @escaping (Context) throws -> Result
+    ) -> Promise<Result, Error> {
+        let loadPromiseCapture = contextPromise.mutate {
+            let capture = !$0.isRejected ? $0 : contextLoad()
+            return capture
+        }
+
+        return loadPromiseCapture.then { context in
+            Promise<Result, Error> { resolve, reject in
+                context.perform {
+                    do {
+                        resolve(try block(context))
+                    } catch {
+                        reject(error)
+                    }
+                }
+            }
+        }
+    }
+}
+
+private extension NSManagedObjectContext {
+    func executeSetStorageDelete(
+        _ request: NSFetchRequest<any NSFetchRequestResult>
+    ) throws {
+        let deleteRequest = NSBatchDeleteRequest(fetchRequest: request)
+        deleteRequest.resultType = .resultTypeStatusOnly
+
+        guard
+            let result = try execute(deleteRequest) as? NSBatchDeleteResult,
+            result.result as? Bool == true
+        else {
+            throw CoreDataSetStorageError.batchDeleteFailed
+        }
+    }
+
+    static func loadSetStorage(
+        directoryURL: URL,
+        storageName: String,
+        migration: @escaping () -> Promise<Void, Error>,
+        model: NSManagedObjectModel
+    ) -> Promise<NSManagedObjectContext, Error> {
+        migration().then {
+            let fileManager = FileManager.default
+
+            guard directoryURL.isFileURL else {
+                throw StorageError.directoryURLIsNotFileURL
+            }
+
+            if !fileManager.fileExists(atPath: directoryURL.path) {
+                try fileManager.createDirectory(
+                    at: directoryURL,
+                    withIntermediateDirectories: true
+                )
+            }
+
+            let url = directoryURL.appendingPathComponent("\(storageName)_\(STORAGE_VERSION)")
+            let container = NSPersistentContainer(
+                name: storageName,
+                managedObjectModel: model
+            )
+            let storeDescription = NSPersistentStoreDescription(url: url)
+            container.persistentStoreDescriptions = [storeDescription]
+
+            return Promise { resolve, reject in
+                container.loadPersistentStores { _, error in
+                    if let error {
+                        reject(error)
+                        return
+                    }
+                    resolve(container.newBackgroundContext())
+                }
+            }
+        }
+    }
+}
+
+public enum CoreDataSetStorageError: Error {
+    case batchDeleteFailed
+    case batchInsertFailed
+    case requestResultNotFound
+}
+
+// Must not be modified. Write new ItemVersion and write migration logic instead.
+@objc(SabyCoreDataSetStorageItemVersion1)
+final class SabyCoreDataSetStorageItemVersion1: NSManagedObject {
+    @NSManaged var data: Data
+    @NSManaged var byte: Int
+}
+
+final class SabyCoreDataSetStorageSchema {
+    let entity: NSEntityDescription
+    let model: NSManagedObjectModel
+
+    init() {
+        let dataAttribute = NSAttributeDescription()
+        dataAttribute.name = "data"
+        if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *) {
+            dataAttribute.type = .binaryData
+        } else {
+            dataAttribute.attributeType = .binaryDataAttributeType
+        }
+
+        let byteAttribute = NSAttributeDescription()
+        byteAttribute.name = "byte"
+        if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *) {
+            byteAttribute.type = .integer64
+        } else {
+            byteAttribute.attributeType = .integer64AttributeType
+        }
+
+        let itemEntity = NSEntityDescription()
+        itemEntity.name = String(describing: SabyCoreDataSetStorageItemVersion1.self)
+        itemEntity.managedObjectClassName = String(describing: SabyCoreDataSetStorageItemVersion1.self)
+        itemEntity.properties = [
+            dataAttribute,
+            byteAttribute
+        ]
+
+        let model = NSManagedObjectModel()
+        model.entities = [itemEntity]
+
+        self.entity = itemEntity
+        self.model = model
+    }
+}

--- a/Source/AppleStorage/Implement/CoreDataSetStorage.swift
+++ b/Source/AppleStorage/Implement/CoreDataSetStorage.swift
@@ -19,7 +19,11 @@ public final class CoreDataSetStorage<Value: Codable & Hashable>: SetStorage {
     let contextLoad: () -> Promise<Context, Error>
     let contextPromise: Atomic<Promise<Context, Error>>
 
-    let encoder = JSONEncoder.acceptingNonConfirmingFloat()
+    let encoder: JSONEncoder = {
+        let encoder = JSONEncoder.acceptingNonConfirmingFloat()
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }()
     let decoder = JSONDecoder.acceptingNonConfirmingFloat()
 
     public init(
@@ -78,6 +82,15 @@ extension CoreDataSetStorage {
             }
 
             return values
+        }
+    }
+
+    public func contains(_ value: Value) -> Promise<Bool, Error> {
+        execute { context in
+            let data = try self.encoder.encode(value)
+            let request = self.createContainsRequest(data: data)
+
+            return try context.fetch(request).isEmpty == false
         }
     }
 
@@ -147,6 +160,16 @@ extension CoreDataSetStorage {
         request.entity = entity
         request.propertiesToFetch = ["data"]
         request.resultType = .dictionaryResultType
+
+        return request
+    }
+
+    fileprivate func createContainsRequest(data: Data) -> NSFetchRequest<NSManagedObjectID> {
+        let request = NSFetchRequest<NSManagedObjectID>()
+        request.entity = entity
+        request.predicate = NSPredicate(format: "data == %@", data as NSData)
+        request.fetchLimit = 1
+        request.resultType = .managedObjectIDResultType
 
         return request
     }
@@ -287,6 +310,17 @@ final class SabyCoreDataSetStorageSchema {
         itemEntity.properties = [
             dataAttribute,
             byteAttribute
+        ]
+        itemEntity.indexes = [
+            NSFetchIndexDescription(
+                name: "SabyCoreDataSetStorageDataIndex",
+                elements: [
+                    NSFetchIndexElementDescription(
+                        property: dataAttribute,
+                        collationType: .binary
+                    )
+                ]
+            )
         ]
 
         let model = NSManagedObjectModel()

--- a/Source/AppleStorage/SetStorage.swift
+++ b/Source/AppleStorage/SetStorage.swift
@@ -11,6 +11,7 @@ public protocol SetStorage<Value>: Storage {
 
     func set(_ values: Set<Value>) -> Promise<Void, Error>
     func get() -> Promise<Set<Value>, Error>
+    func contains(_ value: Value) -> Promise<Bool, Error>
     func clear() -> Promise<Void, Error>
 
     func count() -> Promise<Int, Error>

--- a/Source/AppleStorage/SetStorage.swift
+++ b/Source/AppleStorage/SetStorage.swift
@@ -1,0 +1,18 @@
+//
+//  SetStorage.swift
+//  SabyAppleStorage
+//
+
+import SabyConcurrency
+import SabySize
+
+public protocol SetStorage<Value>: Storage {
+    associatedtype Value: Hashable
+
+    func set(_ values: Set<Value>) -> Promise<Void, Error>
+    func get() -> Promise<Set<Value>, Error>
+    func clear() -> Promise<Void, Error>
+
+    func count() -> Promise<Int, Error>
+    func size() -> Promise<Volume, Error>
+}

--- a/Test/AppleStorage/Implement/CoreDataSetStorageTest.swift
+++ b/Test/AppleStorage/Implement/CoreDataSetStorageTest.swift
@@ -1,0 +1,56 @@
+//
+//  CoreDataSetStorageTest.swift
+//  SabyAppleStorageTest
+//
+
+import XCTest
+@testable import SabyAppleStorage
+
+private struct SetValue: Codable, Hashable {
+    let id: Int
+}
+
+final class CoreDataSetStorageTest: XCTestCase {
+    private var storage: CoreDataSetStorage<SetValue>!
+
+    override func setUpWithError() throws {
+        storage = CoreDataSetStorage(
+            directoryURL: FileManager.default.temporaryDirectory,
+            storageName: "\(UUID())"
+        )
+    }
+
+    override func tearDownWithError() throws {
+        try storage.clear().wait()
+    }
+
+    func test__set_replaces_existing_values() throws {
+        try storage.set([SetValue(id: 0), SetValue(id: 1)]).wait()
+
+        let expected: Set<SetValue> = [SetValue(id: 2), SetValue(id: 3)]
+        try storage.set(expected).wait()
+
+        XCTAssertEqual(try storage.get().wait(), expected)
+        XCTAssertEqual(try storage.count().wait(), expected.count)
+    }
+
+    func test__set_empty_clears_existing_values() throws {
+        try storage.set([SetValue(id: 0)]).wait()
+
+        try storage.set([]).wait()
+
+        XCTAssertEqual(try storage.get().wait(), [])
+        XCTAssertEqual(try storage.count().wait(), 0)
+        XCTAssertEqual(try storage.size().wait().byte, 0)
+    }
+
+    func test__set_and_get_100_000_values() throws {
+        let expected = Set((0 ..< 100_000).map(SetValue.init(id:)))
+
+        try storage.set(expected).wait()
+        let actual = try storage.get().wait()
+
+        XCTAssertEqual(actual, expected)
+        XCTAssertEqual(try storage.count().wait(), expected.count)
+    }
+}

--- a/Test/AppleStorage/Implement/CoreDataSetStorageTest.swift
+++ b/Test/AppleStorage/Implement/CoreDataSetStorageTest.swift
@@ -3,11 +3,17 @@
 //  SabyAppleStorageTest
 //
 
+import CoreData
 import XCTest
 @testable import SabyAppleStorage
 
 private struct SetValue: Codable, Hashable {
     let id: Int
+}
+
+private struct LegacySetValue: Codable, Hashable {
+    let first: Int
+    let second: Int
 }
 
 final class CoreDataSetStorageTest: XCTestCase {
@@ -52,6 +58,28 @@ final class CoreDataSetStorageTest: XCTestCase {
         XCTAssertFalse(try storage.contains(SetValue(id: 1)).wait())
     }
 
+    func test__contains_value_from_legacy_local_database() throws {
+        let storageName = "\(UUID())"
+        let legacyData = Data(#"{"second":2,"first":1}"#.utf8)
+        try createLegacyStorage(storageName: storageName, data: legacyData)
+
+        let storage = CoreDataSetStorage<LegacySetValue>(
+            directoryURL: FileManager.default.temporaryDirectory,
+            storageName: storageName
+        )
+        let existingValue = LegacySetValue(first: 1, second: 2)
+
+        XCTAssertEqual(try storage.get().wait(), [existingValue])
+        XCTAssertTrue(try storage.contains(existingValue).wait())
+        XCTAssertFalse(
+            try storage.contains(LegacySetValue(first: 1, second: 3)).wait()
+        )
+
+        try storage.set([existingValue]).wait()
+        XCTAssertTrue(try storage.contains(existingValue).wait())
+        try storage.clear().wait()
+    }
+
     func test__set_and_get_100_000_values() throws {
         let expected = Set((0 ..< 100_000).map(SetValue.init(id:)))
 
@@ -62,5 +90,72 @@ final class CoreDataSetStorageTest: XCTestCase {
         XCTAssertEqual(try storage.count().wait(), expected.count)
         XCTAssertTrue(try storage.contains(SetValue(id: 99_999)).wait())
         XCTAssertFalse(try storage.contains(SetValue(id: 100_000)).wait())
+    }
+}
+
+private extension CoreDataSetStorageTest {
+    func createLegacyStorage(storageName: String, data: Data) throws {
+        let schema = LegacyCoreDataSetStorageSchema()
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(storageName)_Version1")
+        let container = NSPersistentContainer(
+            name: storageName,
+            managedObjectModel: schema.model
+        )
+        container.persistentStoreDescriptions = [
+            NSPersistentStoreDescription(url: url)
+        ]
+
+        let loadExpectation = expectation(description: "load legacy persistent store")
+        var loadError: Error?
+        container.loadPersistentStores { _, error in
+            loadError = error
+            loadExpectation.fulfill()
+        }
+        wait(for: [loadExpectation], timeout: 5)
+        if let loadError {
+            throw loadError
+        }
+
+        let context = container.newBackgroundContext()
+        try context.performAndWait {
+            let item = SabyCoreDataSetStorageItemVersion1(
+                entity: schema.entity,
+                insertInto: context
+            )
+            item.data = data
+            item.byte = data.count
+            try context.save()
+        }
+
+        for store in container.persistentStoreCoordinator.persistentStores {
+            try container.persistentStoreCoordinator.remove(store)
+        }
+    }
+}
+
+private final class LegacyCoreDataSetStorageSchema {
+    let entity: NSEntityDescription
+    let model: NSManagedObjectModel
+
+    init() {
+        let dataAttribute = NSAttributeDescription()
+        dataAttribute.name = "data"
+        dataAttribute.attributeType = .binaryDataAttributeType
+
+        let byteAttribute = NSAttributeDescription()
+        byteAttribute.name = "byte"
+        byteAttribute.attributeType = .integer64AttributeType
+
+        let entity = NSEntityDescription()
+        entity.name = "SabyCoreDataSetStorageItemVersion1"
+        entity.managedObjectClassName = "SabyCoreDataSetStorageItemVersion1"
+        entity.properties = [dataAttribute, byteAttribute]
+
+        let model = NSManagedObjectModel()
+        model.entities = [entity]
+
+        self.entity = entity
+        self.model = model
     }
 }

--- a/Test/AppleStorage/Implement/CoreDataSetStorageTest.swift
+++ b/Test/AppleStorage/Implement/CoreDataSetStorageTest.swift
@@ -44,6 +44,14 @@ final class CoreDataSetStorageTest: XCTestCase {
         XCTAssertEqual(try storage.size().wait().byte, 0)
     }
 
+    func test__contains() throws {
+        let existingValue = SetValue(id: 0)
+        try storage.set([existingValue]).wait()
+
+        XCTAssertTrue(try storage.contains(existingValue).wait())
+        XCTAssertFalse(try storage.contains(SetValue(id: 1)).wait())
+    }
+
     func test__set_and_get_100_000_values() throws {
         let expected = Set((0 ..< 100_000).map(SetValue.init(id:)))
 
@@ -52,5 +60,7 @@ final class CoreDataSetStorageTest: XCTestCase {
 
         XCTAssertEqual(actual, expected)
         XCTAssertEqual(try storage.count().wait(), expected.count)
+        XCTAssertTrue(try storage.contains(SetValue(id: 99_999)).wait())
+        XCTAssertFalse(try storage.contains(SetValue(id: 100_000)).wait())
     }
 }


### PR DESCRIPTION
## 요약
- SetStorage 프로토콜과 CoreDataSetStorage 구현을 추가했습니다.
- 대량 교체는 batch delete와 batch insert로 처리합니다.
- 조회는 dictionary result를 사용해 NSManagedObject 생성을 피합니다.
- 구형 OS에서는 objects 기반 batch insert로 호환합니다.

## 검증
- swift test --filter CoreDataSetStorageTest: 3개 통과
- 100,000건 set/get 왕복: 통과
- swift test: 332개 통과
- git diff --check: 통과

## 고려사항
- batch delete와 batch insert는 별도 persistent store 요청입니다.