### PR TITLE
feat(network): expose response headers

### DIFF
--- a/Source/Network/Client.swift
+++ b/Source/Network/Client.swift
@@ -68,4 +68,8 @@ public enum ClientMethod: String {
 
 public typealias ClientHeader = Dictionary<String, String>
 
-public typealias ClientResult<Response> = (code2XX: Int, body: Response)
+public typealias ClientResult<Response> = (
+    code2XX: Int,
+    headers: ClientHeader,
+    body: Response
+)

--- a/Source/Network/Implement/Client/DataClient.swift
+++ b/Source/Network/Implement/Client/DataClient.swift
@@ -84,7 +84,11 @@ extension DataClient {
                 return
             }
 
-            pending.resolve((code2XX: code, body: data))
+            pending.resolve((
+                code2XX: code,
+                headers: response.clientHeaders,
+                body: data
+            ))
         }
         pending.onCancel {
             task.cancel()
@@ -131,4 +135,13 @@ public enum DataClientError: Error {
     case timeout
     case statusCodeNotFound
     case statusCodeNot2XX(codeNot2XX: Int, body: Data?)
+}
+
+private extension HTTPURLResponse {
+    var clientHeaders: ClientHeader {
+        allHeaderFields.reduce(into: [:]) { headers, field in
+            guard let key = field.key as? String else { return }
+            headers[key] = String(describing: field.value)
+        }
+    }
 }

--- a/Source/Network/Implement/Client/JSONClient.swift
+++ b/Source/Network/Implement/Client/JSONClient.swift
@@ -60,13 +60,13 @@ extension JSONClient {
             timeout: timeout,
             optionBlock: optionBlock
         )
-        .then { code2XX, data -> ClientResult<JSON> in
+        .then { code2XX, headers, data -> ClientResult<JSON> in
             guard let data, let body = try? JSON.parse(data) else {
                 throw JSONClientError.responseDataIsNotDecodable(code: code2XX, body: data)
             }
             
             
-            return (code2XX, body)
+            return (code2XX, headers, body)
         }
         .catch { error in
             if case DataClientError.timeout = error {

--- a/Source/TestMock/MockURLProtocol.swift
+++ b/Source/TestMock/MockURLProtocol.swift
@@ -72,12 +72,27 @@ public struct URLResult {
     let data: Promise<Data?, Never>
     let error: Error?
     
-    public init(url: URL, code: Int, data: Data?) {
-        self.init(url: url, code: code, data: .resolved(data))
+    public init(
+        url: URL,
+        code: Int,
+        headers: [String: String] = [:],
+        data: Data?
+    ) {
+        self.init(url: url, code: code, headers: headers, data: .resolved(data))
     }
     
-    public init(url: URL, code: Int, data: Promise<Data?, Never>) {
-        let response = HTTPURLResponse(url: url, statusCode: code, httpVersion: nil, headerFields: nil)
+    public init(
+        url: URL,
+        code: Int,
+        headers: [String: String] = [:],
+        data: Promise<Data?, Never>
+    ) {
+        let response = HTTPURLResponse(
+            url: url,
+            statusCode: code,
+            httpVersion: nil,
+            headerFields: headers
+        )
         
         self.url = url
         self.response = response
@@ -85,12 +100,27 @@ public struct URLResult {
         self.error = nil
     }
     
-    public init(url: URL, code: Int, json: JSON) {
-        self.init(url: url, code: code, json: .resolved(json))
+    public init(
+        url: URL,
+        code: Int,
+        headers: [String: String] = [:],
+        json: JSON
+    ) {
+        self.init(url: url, code: code, headers: headers, json: .resolved(json))
     }
     
-    public init(url: URL, code: Int, json: Promise<JSON, Never>) {
-        let response = HTTPURLResponse(url: url, statusCode: code, httpVersion: nil, headerFields: nil)
+    public init(
+        url: URL,
+        code: Int,
+        headers: [String: String] = [:],
+        json: Promise<JSON, Never>
+    ) {
+        let response = HTTPURLResponse(
+            url: url,
+            statusCode: code,
+            httpVersion: nil,
+            headerFields: headers
+        )
         
         self.url = url
         self.response = response

--- a/Test/Network/DataClientTest.swift
+++ b/Test/Network/DataClientTest.swift
@@ -36,6 +36,7 @@ final class DataClientTest: XCTestCase {
                 URLResult(
                     url: URL(string: "https://mock.api.ab180.co/request")!,
                     code: 200,
+                    headers: ["X-Response-ID": "success"],
                     data: Data()
                 )
             ]
@@ -46,7 +47,13 @@ final class DataClientTest: XCTestCase {
         
         let response = client.request(URL(string: "https://mock.api.ab180.co/request")!)
         
-        Expect.promise(response, state: .resolved({ $0 == (200, Data()) }), timeout: .seconds(2))
+        Expect.promise(
+            response,
+            state: .resolved({
+                $0 == (200, ["X-Response-ID": "success"], Data())
+            }),
+            timeout: .seconds(2)
+        )
     }
     
     func test__request_reponse_code_not_2XX() {

--- a/Test/Network/JSONClientTest.swift
+++ b/Test/Network/JSONClientTest.swift
@@ -37,6 +37,7 @@ final class JSONClientTest: XCTestCase {
                 URLResult(
                     url: URL(string: "https://mock.api.ab180.co/request")!,
                     code: 200,
+                    headers: ["X-Response-ID": "success"],
                     data: try! JSON.from([:]).datafy()
                 )
             ]
@@ -52,7 +53,9 @@ final class JSONClientTest: XCTestCase {
         
         Expect.promise(
             response,
-            state: .resolved({ $0 == (200, [:]) }),
+            state: .resolved({
+                $0 == (200, ["X-Response-ID": "success"], [:])
+            }),
             timeout: .seconds(2)
         )
     }


### PR DESCRIPTION
## Summary
- expose response headers through `ClientResult`
- forward headers from `DataClient` through `JSONClient`
- extend network mocks and tests with response headers

## Validation
- `swift test --filter SabyNetworkTest` (15 tests)
- `swift test` (329 tests)